### PR TITLE
Change submodules to use HTTPS instead of Git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,33 +1,33 @@
 [submodule "zsh/oh-my-zsh.symlink"]
 	path = zsh/oh-my-zsh.symlink
-	url = git://github.com/augustash/oh-my-zsh.git
+	url = https://github.com/augustash/oh-my-zsh.git
 [submodule "vim/vim.symlink/bundle/gist-vim"]
 	path = vim/vim.symlink/bundle/gist-vim
-	url = git://github.com/mattn/gist-vim.git
+	url = https://github.com/mattn/gist-vim.git
 [submodule "vim/vim.symlink/bundle/vim-fugitive"]
 	path = vim/vim.symlink/bundle/vim-fugitive
-	url = git://github.com/tpope/vim-fugitive.git
+	url = https://github.com/tpope/vim-fugitive.git
 [submodule "vim/vim.symlink/bundle/vim-git"]
 	path = vim/vim.symlink/bundle/vim-git
-	url = git://github.com/tpope/vim-git.git
+	url = https://github.com/tpope/vim-git.git
 [submodule "vim/vim.symlink/bundle/vim-markdown"]
 	path = vim/vim.symlink/bundle/vim-markdown
-	url = git://github.com/tpope/vim-markdown.git
+	url = https://github.com/tpope/vim-markdown.git
 [submodule "vim/vim.symlink/bundle/vim-repeat"]
 	path = vim/vim.symlink/bundle/vim-repeat
-	url = git://github.com/tpope/vim-repeat.git
+	url = https://github.com/tpope/vim-repeat.git
 [submodule "vim/vim.symlink/bundle/vim-surround"]
 	path = vim/vim.symlink/bundle/vim-surround
-	url = git://github.com/tpope/vim-surround.git
+	url = https://github.com/tpope/vim-surround.git
 [submodule "vim/vim.symlink/bundle/vim-unimpaired"]
 	path = vim/vim.symlink/bundle/vim-unimpaired
-	url = git://github.com/tpope/vim-unimpaired.git
+	url = https://github.com/tpope/vim-unimpaired.git
 [submodule "vim/vim.symlink/bundle/vim-commentary"]
 	path = vim/vim.symlink/bundle/vim-commentary
-	url = git://github.com/tpope/vim-commentary.git
+	url = https://github.com/tpope/vim-commentary.git
 [submodule "vim/vim.symlink/bundle/vim-colors-solarized"]
 	path = vim/vim.symlink/bundle/vim-colors-solarized
-	url = git://github.com/altercation/vim-colors-solarized.git
+	url = https://github.com/altercation/vim-colors-solarized.git
 [submodule "vim/vim.symlink/bundle/snipmate"]
 	path = vim/vim.symlink/bundle/snipmate
-	url = git://github.com/msanders/snipmate.vim.git
+	url = https://github.com/msanders/snipmate.vim.git

--- a/README.md
+++ b/README.md
@@ -2,44 +2,44 @@
 
 ## Dotfiles
 
-Your dotfiles are how you personalize your system. We liked Holman's idea of 
-breaking these files up in a topical fashion. It makes managing these files 
+Your dotfiles are how you personalize your system. We liked Holman's idea of
+breaking these files up in a topical fashion. It makes managing these files
 much easier. [Read his post on the subject](http://zachholman.com/2010/08/dotfiles-are-meant-to-be-forked/).
 
 ## Install
 
-- `git clone git://github.com/augustash/serverdots.git ~/.dotfiles`
+- `git clone https://github.com/augustash/serverdots.git ~/.dotfiles`
 - `cd ~/.dotfiles`
 - `git submodule init`
 - `git submodule update`
 - `rake install`
 - `chsh -s /bin/zsh`
 
-The install rake task will symlink the appropriate files in `.dotfiles` to 
+The install rake task will symlink the appropriate files in `.dotfiles` to
 your home directory. Everything is configured and tweaked within `~/.dotfiles`.
 
-The main file you'll want to change is `zsh/zshrc.symlink`, which sets up a few 
+The main file you'll want to change is `zsh/zshrc.symlink`, which sets up a few
 paths that'll be different across your machines.
 
 ## Topical
 
-Everything's built around topic areas. If you're adding a new area to your 
-dotfiles - say, "PHP" - you can simply add a `php` directory and put files in 
-there. Anything with an extension of `.zsh` will get automatically included 
-into your shell. Anything with an extension of `.symlink` will get symlinked 
+Everything's built around topic areas. If you're adding a new area to your
+dotfiles - say, "PHP" - you can simply add a `php` directory and put files in
+there. Anything with an extension of `.zsh` will get automatically included
+into your shell. Anything with an extension of `.symlink` will get symlinked
 without extension into `$HOME` when you run `rake install`.
 
 ## Components
 
 There's a few special files in the hierarchy.
 
-- **bin/**: Anything in `bin/` will get added to your `$PATH` and be made 
+- **bin/**: Anything in `bin/` will get added to your `$PATH` and be made
   available everywhere.
 - **topic/\*.zsh**: Any files ending in `.zsh` get loaded into your
   environment.
 - **topic/\*.symlink**: Any files ending in `*.symlink` get symlinked into
   your `$HOME`. This is so you can keep all of them versioned in your dotfiles
-  but still keep them autoloaded in your home directory. These get symlinked 
+  but still keep them autoloaded in your home directory. These get symlinked
   in when you run `rake install`.
 - **topic/\*.completion.sh**: Any files ending in `completion.sh` get loaded
   last so that they get loaded after Zsh autocomplete functions are setup.
@@ -55,7 +55,7 @@ dependency, but if you install them they'll make your life better too.
 
 ## Thanks
 
-I've formed these dotfiles over many iterations and borrowed ideas from many 
+I've formed these dotfiles over many iterations and borrowed ideas from many
 super smart dudes:
 
 * [Ryan Bates](https://github.com/ryanb)


### PR DESCRIPTION
Because some servers may not have their firewalls open to the Git port,
but typically have port 443 open.
